### PR TITLE
fix(docker): correct Qt6 package names for Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     git \
     qt6-base-dev \
     qt6-websockets-dev \
-    qt6-l10n-tools \
+    qt6-tools-dev \
     libgl1-mesa-dev \
     libxkbcommon-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libqt6sql6t64 \
     libqt6sql6-mysql \
     libqt6concurrent6t64 \
-    libqt6websockets6t64 \
+    libqt6websockets6 \
     libgl1 \
     libxkbcommon0 \
     ca-certificates \


### PR DESCRIPTION
Two package name fixes for the Dockerfile targeting `ubuntu:24.04`:

1. **Build stage** — Replace `qt6-l10n-tools` with `qt6-tools-dev`
   - `qt6-l10n-tools` only provides the CLI tools (e.g., `lrelease`, `lupdate`)
   - `qt6-tools-dev` provides `Qt6LinguisticToolsConfig.cmake` which the CMake build expects

2. **Runtime stage** — Replace `libqt6websockets6t64` with `libqt6websockets6`
   - The `*t64` variant does not exist on Ubuntu 24.04 for this package
   - The correct package providing `libQt6WebSockets.so.6` is `libqt6websockets6`

Verified by building successfully via Kaniko on Ubuntu 24.04.