### PR TITLE
feat(core): optional external Manticore Search via manticoreHost config

### DIFF
--- a/src/api/configmanager.cpp
+++ b/src/api/configmanager.cpp
@@ -83,7 +83,10 @@ void ConfigManager::setDefaults()
         {"autoStart", false},
         {"checkUpdatesOnStartup", true},
         {"dataDirectory", QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)},
-        
+
+        // Database
+        {"manticoreHost", ""},
+
         // Legal
         {"agreementAccepted", false}
     };
@@ -171,6 +174,15 @@ void ConfigManager::validateAndClamp()
     if (!config_["p2pReplicationServer"].toBool() && config_["p2pReplication"].toBool()) {
         config_["p2pReplication"] = false;
     }
+}
+
+// ============================================================================
+// Database Settings
+// ============================================================================
+
+QString ConfigManager::manticoreHost() const { return config_["manticoreHost"].toString(); }
+void ConfigManager::setManticoreHost(const QString& host) {
+    if (setValue("manticoreHost", host)) emit manticoreHostChanged(host);
 }
 
 // ============================================================================

--- a/src/api/configmanager.h
+++ b/src/api/configmanager.h
@@ -49,6 +49,11 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoStart READ autoStart WRITE setAutoStart NOTIFY autoStartChanged)
     Q_PROPERTY(bool checkUpdatesOnStartup READ checkUpdatesOnStartup WRITE setCheckUpdatesOnStartup NOTIFY checkUpdatesOnStartupChanged)
     Q_PROPERTY(QString dataDirectory READ dataDirectory WRITE setDataDirectory NOTIFY dataDirectoryChanged)
+
+    // Database
+    Q_PROPERTY(QString manticoreHost READ manticoreHost WRITE setManticoreHost NOTIFY manticoreHostChanged)
+
+    // Legal
     Q_PROPERTY(bool agreementAccepted READ agreementAccepted WRITE setAgreementAccepted NOTIFY agreementAcceptedChanged)
 
 public:
@@ -212,7 +217,14 @@ public:
     
     bool agreementAccepted() const;
     void setAgreementAccepted(bool accepted);
-    
+
+    // =========================================================================
+    // Database Settings
+    // =========================================================================
+
+    QString manticoreHost() const;
+    void setManticoreHost(const QString& host);
+
     // =========================================================================
     // Generic Access (for API)
     // =========================================================================
@@ -261,7 +273,10 @@ signals:
     void checkUpdatesOnStartupChanged(bool enabled);
     void dataDirectoryChanged(const QString& path);
     void agreementAcceptedChanged(bool accepted);
-    
+
+    // Database signals
+    void manticoreHostChanged(const QString& host);
+
     // Filter signals
     void filtersMaxFilesChanged(int max);
     void filtersNamingRegExpChanged(const QString& regexp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,12 @@ int runConsoleMode(QCoreApplication& app, int p2pPort, int dhtPort, const QStrin
     // Initialize database
     TorrentDatabase database(dataDir);
     g_database = &database;
-    
+
+    // Configure remote Manticore host before initialize (empty = embedded)
+    if (!config.manticoreHost().isEmpty()) {
+        database.setManticoreHost(config.manticoreHost());
+    }
+
     if (!database.initialize()) {
         qCritical() << "Failed to initialize database";
         return 1;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -558,6 +558,12 @@ void MainWindow::startServices()
     
     // Initialize database (this starts Manticore - the slowest part)
     qint64 dbStart = timer.elapsed();
+
+    // Configure remote Manticore host before initialize (empty = embedded)
+    if (config && !config->manticoreHost().isEmpty()) {
+        torrentDatabase->setManticoreHost(config->manticoreHost());
+    }
+
     if (!torrentDatabase->initialize()) {
         QMessageBox::critical(this, tr("Error"), tr("Failed to initialize database!"));
         return;

--- a/src/manticoremanager.cpp
+++ b/src/manticoremanager.cpp
@@ -50,6 +50,7 @@ ManticoreManager::ManticoreManager(const QString& dataDirectory, QObject *parent
     , status_(Status::Stopped)
     , isExternalInstance_(false)
     , isWindowsDaemonMode_(false)
+    , hostname_()
 {
     databasePath_ = dataDirectory_ + "/database";
     configPath_ = dataDirectory_ + "/sphinx.conf";
@@ -95,12 +96,31 @@ bool ManticoreManager::start()
     if (status_ == Status::Running) {
         return true;
     }
-    
+
     QElapsedTimer startupTimer;
     startupTimer.start();
-    
+
     isWindowsDaemonMode_ = false;
-    
+
+    // ====================================================================
+    // Remote mode: connect to an existing external Manticore instance
+    // ====================================================================
+    if (!hostname_.isEmpty()) {
+        qInfo() << "Using remote Manticore at" << hostname_ << ":" << port_;
+
+        if (testConnection()) {
+            isExternalInstance_ = true;
+            setStatus(Status::Running);
+            emit started();
+            qInfo() << "Connected to remote Manticore in" << startupTimer.elapsed() << "ms";
+            return true;
+        }
+
+        emit error(QString("Cannot connect to remote Manticore at %1:%2").arg(hostname_).arg(port_));
+        setStatus(Status::Error);
+        return false;
+    }
+
     // Check if external instance is running via PID file (fast check first)
     if (QFile::exists(pidFilePath_)) {
         QFile pidFile(pidFilePath_);
@@ -297,7 +317,7 @@ QSqlDatabase ManticoreManager::getDatabase() const
     
     if (!QSqlDatabase::contains(threadConnName)) {
         QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL", threadConnName);
-        db.setHostName("127.0.0.1");
+        db.setHostName(hostname_.isEmpty() ? QStringLiteral("127.0.0.1") : hostname_);
         db.setPort(port_);
         db.setDatabaseName("");
         db.setConnectOptions("MYSQL_OPT_RECONNECT=1");
@@ -679,7 +699,7 @@ bool ManticoreManager::testConnection()
     
     {
         QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL", testConnName);
-        db.setHostName("127.0.0.1");
+        db.setHostName(hostname_.isEmpty() ? QStringLiteral("127.0.0.1") : hostname_);
         db.setPort(port_);
         db.setDatabaseName("");
         // Set short connection timeout (1 second instead of default ~30s)

--- a/src/manticoremanager.h
+++ b/src/manticoremanager.h
@@ -65,6 +65,13 @@ public:
     void setPort(int port) { port_ = port; }
 
     /**
+     * @brief Set remote Manticore hostname. When non-empty, the manager
+     * skips the local searchd process and connects to the remote instance.
+     * Default: empty string (embedded mode).
+     */
+    void setHostname(const QString& hostname) { hostname_ = hostname; }
+
+    /**
      * @brief Get database path
      */
     QString databasePath() const { return databasePath_; }
@@ -142,6 +149,7 @@ private:
     bool isExternalInstance_;
     bool isWindowsDaemonMode_;
     QString connectionName_;
+    QString hostname_;
 };
 
 #endif // MANTICOREMANAGER_H

--- a/src/torrentdatabase.cpp
+++ b/src/torrentdatabase.cpp
@@ -25,7 +25,12 @@ bool TorrentDatabase::initialize()
     
     // Create manager
     manager_ = std::make_unique<ManticoreManager>(dataDirectory_, this);
-    
+
+    // Pass remote hostname (empty = embedded mode) before start
+    if (!manticoreHost_.isEmpty()) {
+        manager_->setHostname(manticoreHost_);
+    }
+
     connect(manager_.get(), &ManticoreManager::error, this, [this](const QString& msg) {
         emit databaseError(msg);
     });

--- a/src/torrentdatabase.h
+++ b/src/torrentdatabase.h
@@ -104,6 +104,12 @@ public:
      * Starts Manticore and prepares tables
      */
     bool initialize();
+
+    /**
+     * @brief Set remote Manticore hostname
+     * Must be called before initialize(). Empty = embedded mode (default).
+     */
+    void setManticoreHost(const QString& host) { manticoreHost_ = host; }
     
     /**
      * @brief Close the database
@@ -318,6 +324,7 @@ private:
     bool addFilesToDatabase(const TorrentInfo& torrent);
     
     QString dataDirectory_;
+    QString manticoreHost_;
     std::unique_ptr<ManticoreManager> manager_;
     std::unique_ptr<SphinxQL> sphinxQL_;
     qint64 nextTorrentId_ = 1;


### PR DESCRIPTION
### Summary

Add a `manticoreHost` config key (default: empty). When set to a non-empty hostname/IP, rats-search connects to that remote Manticore instance instead of starting its own embedded `searchd` process.

### Motivation

This allows multiple rats-search instances (or other services) to share a single Manticore backing store, eliminating the need to synchronise databases between nodes via slow P2P replication or manual export/import scripts. In multi-instance deployments (Docker, K3s, LAN) you can run one Manticore and point all rats-search nodes at it.

### Changes

- **ConfigManager** — new `manticoreHost` property with Q_PROPERTY, getter, setter, signal. Default: `""` (embedded mode, backwards compatible).
- **ManticoreManager** — `setHostname()` method. When hostname is non-empty, `start()` skips the local `searchd` process and connects to the remote instance. `getDatabase()` and `testConnection()` use the hostname instead of the hardcoded `127.0.0.1`.
- **TorrentDatabase** — `setManticoreHost()` passes through to ManticoreManager before `initialize()`.
- **main.cpp** (console mode) + **mainwindow.cpp** (GUI mode) — wire the config value to TorrentDatabase before initialize.

### Backwards compatibility

100% backwards compatible. The default `manticoreHost: ""` preserves the existing embedded searchd behaviour. Setting it to any non-empty value switches to remote mode. No existing config files break.

### Usage

```json
{
  "manticoreHost": "192.168.1.10",
  "httpPort": 8095
}
```

Or via the REST API:
```
curl /api/config.set?manticoreHost=192.168.1.10
```

### Open questions for upstream

1. **Port config** — currently uses the existing `dhtPort` (9306 default) for the Manticore MySQL protocol port. Should this be a separate config (`manticorePort`) instead?
2. **Credentials** — no auth support yet. Remote Manticore is assumed to be on a trusted network. Should manticoreUser/manticorePassword be added?
3. **Connection retry** — no reconnect logic yet. If the remote Manticore goes down, the rats-search instance loses its database. Should we add a reconnection timer?