### PR TITLE
Adding ability to export database ( Fixes #277 )

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -118,7 +118,7 @@ See [WebSocket Events](#websocket-events) for details.
 | `torrent.cleanup` | Re-apply the filter policy to the index and drop torrents that no longer pass |
 | `torrent.create` | Create a `.torrent` file (optionally start seeding) |
 | `torrent.import` | Parse a `.torrent` file and index it |
-| `database.export` | Write the whole index to a portable `.ratsdb` dump |
+| `database.export` | Write the whole index to a file (`.ratsdb`, CSV or JSON Lines) |
 | `database.import` | Merge a `.ratsdb` dump into the index |
 | `database.pull` | Ask a connected peer for its whole index |
 | `database.status` | Current state of the running database sync |
@@ -413,17 +413,41 @@ Only one database operation runs at a time. All three starting methods return
 immediately with the sync status; progress arrives as `databaseSyncProgress`
 WebSocket events and the outcome as `databaseSyncFinished`.
 
-#### `database.export` - Write the index to a dump file
+#### `database.export` - Write the index to a file
 
 ```
 GET http://localhost:8095/api/database.export?path=C:/backup/index.ratsdb
+GET http://localhost:8095/api/database.export?path=C:/backup/index.csv&includeFiles=true
 ```
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `path` (or `file`) | string | yes | | Destination `.ratsdb` file |
+| `path` (or `file`) | string | yes | | Destination file |
+| `format` | string | no | from the extension | `ratsdb`, `csv` or `jsonl` |
+| `includeFiles` | bool | no | `false` | CSV only: also write `<base>.files.csv` |
 
-**Response** - the sync status object (see `database.status`).
+Three formats are available. Only `ratsdb` can be given back to
+`database.import` — CSV and JSON Lines are one-way, written for other programs
+to read:
+
+| Format | Extensions | Contents |
+|--------|-----------|----------|
+| `ratsdb` | `.ratsdb`, anything unrecognised | Compressed portable dump. Lossless, re-importable, and what a peer transfer sends. |
+| `csv` | `.csv` | RFC 4180 spreadsheet, UTF-8 BOM, one row per torrent. The file list is flat-out impossible in one CSV, so `includeFiles` writes it as a companion `<base>.files.csv` (`hash,path,size`) that joins back on `hash`. |
+| `jsonl` | `.jsonl`, `.ndjson`, `.json` | Newline-delimited JSON, one torrent per line, no preamble. The same object `search.torrents` returns, so it is lossless. Reads directly into `jq`, `pandas.read_json(lines=True)` and DuckDB. |
+
+Omitting `format` picks it from the file extension; naming it explicitly is for
+paths without a recognisable suffix. An unknown name is rejected rather than
+silently writing a different format.
+
+Note that CSV escapes a leading `=`, `+`, `-` or `@` with an apostrophe, and
+replaces control characters with spaces, so that torrent names — which are
+written by strangers on the DHT — cannot execute as formulas in a spreadsheet.
+Names are therefore not always byte-identical to the index; use `jsonl` when
+they must be.
+
+**Response** - the sync status object (see `database.status`), including the
+`format` that was chosen.
 
 ---
 

--- a/src/rest/api_router.cpp
+++ b/src/rest/api_router.cpp
@@ -617,8 +617,26 @@ void ApiRouter::registerMethods()
             return;
         }
         const QString path = params.contains("path") ? params["path"].toString() : params["file"].toString();
+
+        // No "format" means "take it from the extension", which is what the GUI
+        // relies on; naming one explicitly is for callers exporting to a path
+        // that does not carry a recognisable suffix.
+        service::DatabaseSyncService::ExportSettings settings;
+        if (params.contains("format")) {
+            const QString name = params["format"].toString();
+            const std::optional<service::ExportFormat> format = service::exportFormatFromName(name);
+            if (!format) {
+                respond(Result::failure(
+                    QStringLiteral("Unknown export format \"%1\" (expected ratsdb, csv or jsonl)").arg(name)));
+                return;
+            }
+            settings.format = format;
+        }
+        // CSV only: write the file list as a companion "<base>.files.csv".
+        settings.includeFiles = params["includeFiles"].toBool(false);
+
         QString error;
-        if (!sync->exportToFile(path, &error)) {
+        if (!sync->exportToFile(path, settings, &error)) {
             respond(Result::failure(error));
             return;
         }

--- a/src/services/database_dump.cpp
+++ b/src/services/database_dump.cpp
@@ -45,11 +45,11 @@ bool writeBlock(QFile& file, const QByteArray& payload)
     return writeU32(file, static_cast<quint32>(payload.size())) && file.write(payload) == payload.size();
 }
 
-QByteArray headerToJson(const dump::Header& header)
+QByteArray headerToJson(const ExportHeader& header)
 {
     QJsonObject obj;
     obj["format"] = QStringLiteral("rats-search-db");
-    obj["version"] = static_cast<int>(header.version);
+    obj["version"] = static_cast<int>(dump::kFormatVersion);
     obj["client"] = header.client;
     obj["peerId"] = header.peerId;
     obj["created"] = (header.created.isValid() ? header.created : QDateTime::currentDateTime()).toString(Qt::ISODate);
@@ -83,7 +83,7 @@ DumpWriter::~DumpWriter()
         abort();
 }
 
-bool DumpWriter::open(const QString& path, const dump::Header& header, QString* error)
+bool DumpWriter::open(const QString& path, const ExportHeader& header, QString* error)
 {
     file_ = std::make_unique<QFile>(path);
     if (!file_->open(QIODevice::WriteOnly | QIODevice::Truncate)) {

--- a/src/services/database_dump.h
+++ b/src/services/database_dump.h
@@ -2,6 +2,7 @@
 #define RATS_SERVICE_DATABASE_DUMP_H
 
 #include "domain/torrent.h"
+#include "services/export_sink.h"
 
 #include <QDateTime>
 #include <QJsonObject>
@@ -42,15 +43,11 @@ inline constexpr quint32 kFormatVersion = 1;
 // enough that one frame is a few hundred KB.
 inline constexpr int kFrameTorrents = 500;
 
-// What the writer puts in the header / the reader gets out of it. `torrents` is
-// the writer's *estimate* (the row count when the export started); the exact
-// figure lands in the footer.
-struct Header {
+// What the writer puts in the header / the reader gets out of it. Everything
+// but the format version is provenance shared with the other export formats,
+// so it lives on ExportHeader; the exact row totals land in the footer.
+struct Header : ExportHeader {
     quint32 version = kFormatVersion;
-    QString client; // producing client version
-    QString peerId; // producing node's peer id (informational)
-    QDateTime created;
-    qint64 torrents = 0; // estimate, for progress reporting
 };
 
 struct Footer {
@@ -62,32 +59,37 @@ struct Footer {
 } // namespace dump
 
 // Streaming writer. Torrents are buffered until a frame is full, so callers can
-// push one at a time without thinking about batching.
-class DumpWriter {
+// push one at a time without thinking about batching. This is the sink the peer
+// transfer and the "keep my index" export use — the only format a DumpReader on
+// the other end can merge back in.
+class DumpWriter : public TorrentSink {
 public:
     DumpWriter();
-    ~DumpWriter();
+    ~DumpWriter() override;
 
     DumpWriter(const DumpWriter&) = delete;
     DumpWriter& operator=(const DumpWriter&) = delete;
 
     // Create/truncate `path` and write the magic + header. Returns false and
     // fills `error` if the file cannot be opened.
-    bool open(const QString& path, const dump::Header& header, QString* error = nullptr);
+    bool open(const QString& path, const ExportHeader& header, QString* error = nullptr) override;
     bool isOpen() const;
 
     // Queue one torrent; flushes a frame once kFrameTorrents have accumulated.
-    bool write(const domain::Torrent& torrent, QString* error = nullptr);
+    bool write(const domain::Torrent& torrent, QString* error = nullptr) override;
 
     // Flush the pending frame, then write the end marker and the footer. After
     // this the file is a complete dump. Safe to call once.
-    bool finish(QString* error = nullptr);
+    bool finish(QString* error = nullptr) override;
 
     // Abort: closes and removes the partial file.
-    void abort();
+    void abort() override;
+
+    // A dump is lossless, so it always wants the file list.
+    bool needsFiles() const override { return true; }
 
     qint64 torrentsWritten() const { return written_; }
-    qint64 bytesWritten() const;
+    qint64 bytesWritten() const override;
 
 private:
     bool flushFrame(QString* error);

--- a/src/services/database_export.cpp
+++ b/src/services/database_export.cpp
@@ -1,0 +1,116 @@
+#include "services/database_export.h"
+
+#include "domain/torrent_codec.h"
+
+#include <QFile>
+#include <QJsonDocument>
+
+namespace rats::service {
+
+namespace {
+
+// Rows accumulate here and go out in one write(): a syscall per torrent would
+// dominate the runtime of a multi-million-row sweep.
+constexpr int kFlushBytes = 256 * 1024;
+
+void setError(QString* error, const QString& text)
+{
+    if (error)
+        *error = text;
+}
+
+} // namespace
+
+// ===========================================================================
+// JsonLinesWriter
+// ===========================================================================
+
+JsonLinesWriter::JsonLinesWriter() = default;
+
+JsonLinesWriter::~JsonLinesWriter()
+{
+    // Same rule as DumpWriter: a writer that never finished leaves no file, so a
+    // cancelled export cannot be mistaken for a complete one.
+    if (file_ && !finished_)
+        abort();
+}
+
+bool JsonLinesWriter::open(const QString& path, const ExportHeader&, QString* error)
+{
+    file_ = std::make_unique<QFile>(path);
+    if (!file_->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        setError(error, file_->errorString());
+        file_.reset();
+        return false;
+    }
+    return true;
+}
+
+bool JsonLinesWriter::isOpen() const
+{
+    return file_ && file_->isOpen();
+}
+
+bool JsonLinesWriter::write(const domain::Torrent& torrent, QString* error)
+{
+    if (!isOpen()) {
+        setError(error, QStringLiteral("Export file is not open"));
+        return false;
+    }
+
+    pending_ += QJsonDocument(domain::codec::toJson(torrent, { /*includeFiles*/ true, /*includeInfo*/ true }))
+                    .toJson(QJsonDocument::Compact);
+    pending_ += '\n';
+    ++written_;
+
+    if (pending_.size() >= kFlushBytes)
+        return flush(error);
+    return true;
+}
+
+bool JsonLinesWriter::flush(QString* error)
+{
+    if (pending_.isEmpty())
+        return true;
+    if (file_->write(pending_) != pending_.size()) {
+        setError(error, file_->errorString());
+        return false;
+    }
+    pending_.clear();
+    return true;
+}
+
+bool JsonLinesWriter::finish(QString* error)
+{
+    if (finished_)
+        return true;
+    if (!isOpen()) {
+        setError(error, QStringLiteral("Export file is not open"));
+        return false;
+    }
+
+    if (!flush(error))
+        return false;
+
+    file_->close();
+    finished_ = true;
+    return true;
+}
+
+void JsonLinesWriter::abort()
+{
+    if (!file_)
+        return;
+    file_->close();
+    file_->remove();
+    file_.reset();
+    pending_.clear();
+}
+
+qint64 JsonLinesWriter::bytesWritten() const
+{
+    // pending_ has not reached the file yet, but progress should count it.
+    return file_ ? file_->size() + pending_.size() : 0;
+}
+
+} // namespace rats::service

--- a/src/services/database_export.cpp
+++ b/src/services/database_export.cpp
@@ -2,7 +2,11 @@
 
 #include "domain/torrent_codec.h"
 
+#include <QByteArrayList>
+#include <QDateTime>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 
 namespace rats::service {
@@ -17,6 +21,56 @@ void setError(QString* error, const QString& text)
 {
     if (error)
         *error = text;
+}
+
+constexpr char kBom[] = "\xEF\xBB\xBF";
+constexpr char kEol[] = "\r\n";
+constexpr char kTorrentColumns[] = "hash,name,size,files,pieceLength,added,contentType,contentCategory,seeders,"
+                                   "leechers,completed,trackersChecked,good,bad,magnet,poster,description";
+constexpr char kFileColumns[] = "hash,path,size";
+
+// One RFC 4180 field out of untrusted text. The three transformations are the
+// ones spelled out on CsvWriter: flatten control characters, defuse a leading
+// formula trigger, then quote if what is left needs it.
+QByteArray csvField(const QString& value)
+{
+    QString field;
+    field.reserve(value.size() + 2);
+    for (const QChar c : value)
+        field += (c.unicode() < 0x20 || c.unicode() == 0x7F) ? QLatin1Char(' ') : c;
+
+    if (!field.isEmpty()) {
+        const QChar first = field.at(0);
+        if (first == QLatin1Char('=') || first == QLatin1Char('+') || first == QLatin1Char('-')
+            || first == QLatin1Char('@'))
+            field.prepend(QLatin1Char('\''));
+    }
+
+    // Control characters are gone by now, so a comma or a double quote are the
+    // only things left that can force quoting.
+    if (!field.contains(QLatin1Char(',')) && !field.contains(QLatin1Char('"')))
+        return field.toUtf8();
+
+    field.replace(QLatin1Char('"'), QLatin1String("\"\""));
+    return QByteArray("\"") + field.toUtf8() + QByteArray("\"");
+}
+
+// An ISO 8601 UTC instant, or an empty field for "never". Epoch 0 is how a
+// never-scraped torrent is stored, not something that happened in 1970.
+QByteArray csvDate(const QDateTime& when)
+{
+    if (!when.isValid() || when.toSecsSinceEpoch() <= 0)
+        return {};
+    return when.toUTC().toString(Qt::ISODate).toUtf8();
+}
+
+// "index.csv" -> "index.files.csv"; anything else just gains the suffix.
+QString companionFilesPath(const QString& path)
+{
+    const QFileInfo info(path);
+    if (info.suffix().compare(QLatin1String("csv"), Qt::CaseInsensitive) == 0)
+        return info.dir().filePath(info.completeBaseName() + QStringLiteral(".files.csv"));
+    return path + QStringLiteral(".files.csv");
 }
 
 } // namespace
@@ -111,6 +165,145 @@ qint64 JsonLinesWriter::bytesWritten() const
 {
     // pending_ has not reached the file yet, but progress should count it.
     return file_ ? file_->size() + pending_.size() : 0;
+}
+
+// ===========================================================================
+// CsvWriter
+// ===========================================================================
+
+CsvWriter::CsvWriter(Options options) : options_(options) { }
+
+CsvWriter::CsvWriter() : CsvWriter(Options()) { }
+
+CsvWriter::~CsvWriter()
+{
+    if (file_ && !finished_)
+        abort();
+}
+
+bool CsvWriter::open(const QString& path, const ExportHeader&, QString* error)
+{
+    file_ = std::make_unique<QFile>(path);
+    if (!file_->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        setError(error, file_->errorString());
+        file_.reset();
+        return false;
+    }
+    pending_ = QByteArray(kBom) + QByteArray(kTorrentColumns) + QByteArray(kEol);
+
+    if (options_.includeFiles) {
+        filesPath_ = companionFilesPath(path);
+        filesFile_ = std::make_unique<QFile>(filesPath_);
+        if (!filesFile_->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            setError(error, filesFile_->errorString());
+            abort(); // takes the main file with it: half an export is no export
+            return false;
+        }
+        filesPending_ = QByteArray(kBom) + QByteArray(kFileColumns) + QByteArray(kEol);
+    }
+    return true;
+}
+
+bool CsvWriter::isOpen() const
+{
+    return file_ && file_->isOpen();
+}
+
+bool CsvWriter::write(const domain::Torrent& torrent, QString* error)
+{
+    if (!isOpen()) {
+        setError(error, QStringLiteral("Export file is not open"));
+        return false;
+    }
+
+    pending_ += QByteArrayList { csvField(torrent.hash), csvField(torrent.name), QByteArray::number(torrent.size),
+        QByteArray::number(torrent.files), QByteArray::number(torrent.pieceLength), csvDate(torrent.added),
+        csvField(domain::toString(torrent.contentType)), csvField(domain::toString(torrent.contentCategory)),
+        QByteArray::number(torrent.seeders), QByteArray::number(torrent.leechers),
+        QByteArray::number(torrent.completed), csvDate(torrent.trackersChecked), QByteArray::number(torrent.good),
+        QByteArray::number(torrent.bad), csvField(torrent.magnetLink()),
+        csvField(torrent.info.value(QLatin1String("poster")).toString()),
+        csvField(torrent.info.value(QLatin1String("description")).toString()) }
+                    .join(',');
+    pending_ += kEol;
+    ++written_;
+
+    // fileList is populated only when needsFiles() asked the exporter for it.
+    if (filesFile_) {
+        for (const domain::File& file : torrent.fileList) {
+            const QByteArrayList row { csvField(torrent.hash), csvField(file.path), QByteArray::number(file.size) };
+            filesPending_ += row.join(',');
+            filesPending_ += kEol;
+            ++filesWritten_;
+        }
+    }
+
+    if (pending_.size() >= kFlushBytes || filesPending_.size() >= kFlushBytes)
+        return flush(error);
+    return true;
+}
+
+bool CsvWriter::flush(QString* error)
+{
+    if (!pending_.isEmpty()) {
+        if (file_->write(pending_) != pending_.size()) {
+            setError(error, file_->errorString());
+            return false;
+        }
+        pending_.clear();
+    }
+    if (filesFile_ && !filesPending_.isEmpty()) {
+        if (filesFile_->write(filesPending_) != filesPending_.size()) {
+            setError(error, filesFile_->errorString());
+            return false;
+        }
+        filesPending_.clear();
+    }
+    return true;
+}
+
+bool CsvWriter::finish(QString* error)
+{
+    if (finished_)
+        return true;
+    if (!isOpen()) {
+        setError(error, QStringLiteral("Export file is not open"));
+        return false;
+    }
+
+    if (!flush(error))
+        return false;
+
+    file_->close();
+    if (filesFile_)
+        filesFile_->close();
+    finished_ = true;
+    return true;
+}
+
+void CsvWriter::abort()
+{
+    if (file_) {
+        file_->close();
+        file_->remove();
+        file_.reset();
+    }
+    if (filesFile_) {
+        filesFile_->close();
+        filesFile_->remove();
+        filesFile_.reset();
+    }
+    filesPath_.clear();
+    pending_.clear();
+    filesPending_.clear();
+}
+
+qint64 CsvWriter::bytesWritten() const
+{
+    qint64 total = file_ ? file_->size() + pending_.size() : 0;
+    if (filesFile_)
+        total += filesFile_->size() + filesPending_.size();
+    return total;
 }
 
 } // namespace rats::service

--- a/src/services/database_export.h
+++ b/src/services/database_export.h
@@ -66,6 +66,80 @@ private:
     bool finished_ = false;
 };
 
+// Comma-separated values (RFC 4180), for spreadsheets and ad-hoc analysis.
+//
+// This is the lossy sink, deliberately: a CSV row is flat, so the two nested
+// halves of a torrent have to go somewhere. `info` is reduced to the two fields
+// a human reads (poster, description), and the file list moves to a companion
+// file — "<base>.files.csv", one row per file, joined back on `hash` — written
+// only when the caller asks for it. When it is off the exporter skips the
+// per-page file query altogether, which is the expensive half of a full sweep;
+// the `files` *count* column survives either way because it lives on the
+// torrent row itself.
+//
+// Three details exist purely because the audience is Excel:
+//   - a UTF-8 BOM, without which Excel on Windows mojibakes every non-ASCII
+//     name, and a DHT index is full of them;
+//   - CRLF line endings, as the RFC specifies;
+//   - a leading apostrophe on any field starting with =, +, - or @, which Excel
+//     would otherwise execute as a formula. Every name in this database was
+//     written by a stranger on the DHT, so that is untrusted input reaching a
+//     spreadsheet (CWE-1236).
+//
+// Control characters inside a name are replaced with spaces rather than quoted:
+// the RFC does permit embedded newlines inside quotes, but enough real-world
+// parsers mis-handle them that keeping one record on one physical line is worth
+// the substitution.
+class CsvWriter : public TorrentSink {
+public:
+    struct Options {
+        // Also write the companion "<base>.files.csv".
+        bool includeFiles = false;
+    };
+
+    explicit CsvWriter(Options options);
+    // GCC refuses to evaluate a nested struct's member initialisers in a default
+    // argument while the enclosing class is still incomplete — the same reason
+    // DatabaseSyncService::importFromFile carries overloads instead of one — so
+    // the no-argument form is its own constructor.
+    CsvWriter();
+    ~CsvWriter() override;
+
+    CsvWriter(const CsvWriter&) = delete;
+    CsvWriter& operator=(const CsvWriter&) = delete;
+
+    // Create/truncate `path` (and the companion file, when enabled) and queue
+    // the BOM + column headers. `header` is unused: a provenance line would put
+    // something other than a record in a CSV, which no reader expects.
+    bool open(const QString& path, const ExportHeader& header, QString* error = nullptr) override;
+    bool isOpen() const;
+
+    bool write(const domain::Torrent& torrent, QString* error = nullptr) override;
+    bool finish(QString* error = nullptr) override;
+    void abort() override;
+
+    bool needsFiles() const override { return options_.includeFiles; }
+
+    // Companion file path, empty when the file list is not being written.
+    QString filesPath() const { return filesPath_; }
+    qint64 torrentsWritten() const { return written_; }
+    qint64 filesWritten() const { return filesWritten_; }
+    qint64 bytesWritten() const override;
+
+private:
+    bool flush(QString* error);
+
+    Options options_;
+    std::unique_ptr<QFile> file_;
+    std::unique_ptr<QFile> filesFile_;
+    QString filesPath_;
+    QByteArray pending_;
+    QByteArray filesPending_;
+    qint64 written_ = 0;
+    qint64 filesWritten_ = 0;
+    bool finished_ = false;
+};
+
 } // namespace rats::service
 
 #endif // RATS_SERVICE_DATABASE_EXPORT_H

--- a/src/services/database_export.h
+++ b/src/services/database_export.h
@@ -1,0 +1,71 @@
+#ifndef RATS_SERVICE_DATABASE_EXPORT_H
+#define RATS_SERVICE_DATABASE_EXPORT_H
+
+#include "services/export_sink.h"
+
+#include <QByteArray>
+#include <QString>
+#include <memory>
+
+class QFile;
+
+// Interchange export formats: the sinks that write the index for *other*
+// programs to read.
+//
+// Unlike the .ratsdb dump next door these are one-way — nothing here can be
+// imported back — which is exactly what frees them to be uncompressed,
+// human-readable and (for CSV) lossy. Moving an index between two Rats installs
+// is still database_dump.h's job; this is the "open it in something else" half.
+namespace rats::service {
+
+// Newline-delimited JSON (JSONL / NDJSON): one compact JSON object per line.
+//
+// Each line is byte-for-byte the line a .ratsdb frame holds — the same
+// domain::codec::toJson(t, {files, info}) — so the two exports cannot drift
+// apart and JSONL is the lossless view of everything a dump carries. The
+// announcing ipv4/port are absent here because the codec never serialises them;
+// that privacy boundary is inherited, not re-decided.
+//
+// There is deliberately NO metadata/header line: `jq`, pandas
+// (read_json(lines=True)) and DuckDB (read_json_auto) all assume every line is
+// a record, and a preamble would break the format for its only audience. The
+// ExportHeader is therefore accepted and ignored.
+class JsonLinesWriter : public TorrentSink {
+public:
+    JsonLinesWriter();
+    ~JsonLinesWriter() override;
+
+    JsonLinesWriter(const JsonLinesWriter&) = delete;
+    JsonLinesWriter& operator=(const JsonLinesWriter&) = delete;
+
+    // Create/truncate `path`. `header` is unused (see above).
+    bool open(const QString& path, const ExportHeader& header, QString* error = nullptr) override;
+    bool isOpen() const;
+
+    // Append one LF-terminated JSON object, flushing once the buffer is full.
+    bool write(const domain::Torrent& torrent, QString* error = nullptr) override;
+
+    // Flush the buffer and close. Safe to call once.
+    bool finish(QString* error = nullptr) override;
+
+    // Close and remove the partial file.
+    void abort() override;
+
+    // The line embeds "files_list", so the file query is needed.
+    bool needsFiles() const override { return true; }
+
+    qint64 torrentsWritten() const { return written_; }
+    qint64 bytesWritten() const override;
+
+private:
+    bool flush(QString* error);
+
+    std::unique_ptr<QFile> file_;
+    QByteArray pending_;
+    qint64 written_ = 0;
+    bool finished_ = false;
+};
+
+} // namespace rats::service
+
+#endif // RATS_SERVICE_DATABASE_EXPORT_H

--- a/src/services/database_sync_service.cpp
+++ b/src/services/database_sync_service.cpp
@@ -56,6 +56,8 @@ QJsonObject statusToJson(const DatabaseSyncService::Status& s)
     obj["running"] = s.running;
     obj["stage"] = s.stage;
     obj["path"] = s.path;
+    if (!s.format.isEmpty())
+        obj["format"] = s.format;
     obj["peer"] = s.peerId;
     obj["processed"] = static_cast<double>(s.processed);
     obj["total"] = static_cast<double>(s.total);
@@ -210,7 +212,7 @@ void DatabaseSyncService::setSharingEnabled(bool enabled)
 // Export
 // ===========================================================================
 
-bool DatabaseSyncService::exportToFile(const QString& path, QString* error)
+bool DatabaseSyncService::exportToFile(const QString& path, const ExportSettings& settings, QString* error)
 {
     if (path.isEmpty()) {
         if (error)
@@ -225,11 +227,22 @@ bool DatabaseSyncService::exportToFile(const QString& path, QString* error)
     if (!beginOperation(Operation::Export, path, QString(), error))
         return false;
 
-    worker_ = QtConcurrent::run([this, path]() { runExport(path, QString()); });
+    const ExportFormat format = settings.format.value_or(exportFormatForPath(path));
+    ExportOptions options;
+    options.includeFiles = settings.includeFiles;
+    {
+        // Set after beginOperation, which resets the status: this is what tells
+        // an API caller which format a sniffed extension resolved to.
+        QMutexLocker lock(&mutex_);
+        status_.format = exportFormatName(format);
+    }
+
+    worker_ = QtConcurrent::run([this, path, format, options]() { runExport(path, QString(), format, options); });
     return true;
 }
 
-void DatabaseSyncService::runExport(const QString& path, const QString& forPeer)
+void DatabaseSyncService::runExport(
+    const QString& path, const QString& forPeer, ExportFormat format, const ExportOptions& options)
 {
     updateStage(QStringLiteral("exporting"));
 
@@ -244,9 +257,9 @@ void DatabaseSyncService::runExport(const QString& path, const QString& forPeer)
         status_.total = header.torrents;
     }
 
-    DumpWriter writer;
+    const std::unique_ptr<TorrentSink> sink = makeExportSink(format, options);
     QString error;
-    if (!writer.open(path, header, &error)) {
+    if (!sink->open(path, header, &error)) {
         QMetaObject::invokeMethod(this, [this, error]() { finishOperation(false, error); }, Qt::QueuedConnection);
         return;
     }
@@ -263,16 +276,21 @@ void DatabaseSyncService::runExport(const QString& path, const QString& forPeer)
             break;
         afterId = page.last().id;
 
-        QStringList hashes;
-        hashes.reserve(page.size());
-        for (const domain::Torrent& t : page)
-            hashes << t.hash;
-        const QHash<QString, QVector<domain::File>> files = repository_->filesOf(hashes);
+        // A flat sink records only the file *count*, which already lives on the
+        // torrent row — so skip the file query, the expensive half of the sweep.
+        QHash<QString, QVector<domain::File>> files;
+        if (sink->needsFiles()) {
+            QStringList hashes;
+            hashes.reserve(page.size());
+            for (const domain::Torrent& t : page)
+                hashes << t.hash;
+            files = repository_->filesOf(hashes);
+        }
 
         for (const domain::Torrent& t : page) {
             domain::Torrent copy = t;
             copy.fileList = files.value(t.hash);
-            if (!writer.write(copy, &error)) {
+            if (!sink->write(copy, &error)) {
                 ok = false;
                 break;
             }
@@ -284,18 +302,18 @@ void DatabaseSyncService::runExport(const QString& path, const QString& forPeer)
         {
             QMutexLocker lock(&mutex_);
             status_.processed = written;
-            status_.bytes = writer.bytesWritten();
+            status_.bytes = sink->bytesWritten();
         }
         QMetaObject::invokeMethod(this, [this]() { publishProgress(); }, Qt::QueuedConnection);
     }
 
     if (cancelRequested_.load()) {
-        writer.abort();
+        sink->abort();
         QMetaObject::invokeMethod(this, [this]() { finishOperation(false, tr("Cancelled.")); }, Qt::QueuedConnection);
         return;
     }
-    if (!ok || !writer.finish(&error)) {
-        writer.abort();
+    if (!ok || !sink->finish(&error)) {
+        sink->abort();
         const QString reason = error.isEmpty() ? tr("Failed to write the dump.") : error;
         QMetaObject::invokeMethod(this, [this, reason]() { finishOperation(false, reason); }, Qt::QueuedConnection);
         return;
@@ -535,7 +553,10 @@ void DatabaseSyncService::handlePeerRequest(const QString& peerId, const QJsonOb
 
     qInfo() << "[DatabaseSync] serving" << torrents << "torrents to" << peerId.left(8);
     emit statusMessage(tr("Sharing the database with %1…").arg(peerId.left(8)), 5000);
-    worker_ = QtConcurrent::run([this, path, peerId]() { runExport(path, peerId); });
+    // Always a dump, whatever the user last exported by hand: the far end feeds
+    // this straight into DumpReader.
+    worker_
+        = QtConcurrent::run([this, path, peerId]() { runExport(path, peerId, ExportFormat::Ratsdb, ExportOptions()); });
 }
 
 void DatabaseSyncService::handlePeerResponse(const QString& peerId, const QJsonObject& data)

--- a/src/services/database_sync_service.h
+++ b/src/services/database_sync_service.h
@@ -1,12 +1,15 @@
 #ifndef RATS_SERVICE_DATABASE_SYNC_SERVICE_H
 #define RATS_SERVICE_DATABASE_SYNC_SERVICE_H
 
+#include "services/export_sink.h"
+
 #include <QFuture>
 #include <QJsonObject>
 #include <QMutex>
 #include <QObject>
 #include <QString>
 #include <atomic>
+#include <optional>
 
 namespace rats::data {
 class TorrentRepository;
@@ -49,6 +52,13 @@ class DatabaseSyncService : public QObject {
 public:
     enum class Operation { None, Export, Import, PeerPull, PeerServe };
 
+    struct ExportSettings {
+        // Unset means "take the format from the file extension".
+        std::optional<ExportFormat> format;
+        // CSV only: also write the companion "<base>.files.csv".
+        bool includeFiles = false;
+    };
+
     struct ImportOptions {
         // Run the local filter policy over the incoming torrents. On by default:
         // a foreign index must not smuggle content past the user's own filters.
@@ -65,6 +75,7 @@ public:
         bool running = false;
         QString stage; // "exporting", "waiting", "transferring", "importing"
         QString path;
+        QString format; // export only: the chosen format's name
         QString peerId;
         QString error;
         qint64 processed = 0; // torrents read/written so far
@@ -82,7 +93,14 @@ public:
 
     // Start writing the whole index to `path`. Returns false (with `error`) if
     // another operation is already running or the file cannot be created.
-    bool exportToFile(const QString& path, QString* error = nullptr);
+    //
+    // `settings` carries no default argument for the same GCC reason spelled out
+    // on importFromFile below; the one-argument overload supplies it.
+    bool exportToFile(const QString& path, const ExportSettings& settings, QString* error = nullptr);
+    bool exportToFile(const QString& path, QString* error = nullptr)
+    {
+        return exportToFile(path, ExportSettings(), error);
+    }
 
     // Start merging the dump at `path` into the local index.
     //
@@ -135,7 +153,7 @@ signals:
 
 private:
     // Worker bodies (run on a QtConcurrent thread).
-    void runExport(const QString& path, const QString& forPeer);
+    void runExport(const QString& path, const QString& forPeer, ExportFormat format, const ExportOptions& options);
     void runImport(const QString& path, const ImportOptions& options);
 
     // Claim/release the single operation slot.

--- a/src/services/export_sink.cpp
+++ b/src/services/export_sink.cpp
@@ -1,0 +1,63 @@
+#include "services/export_sink.h"
+
+#include "services/database_dump.h"
+#include "services/database_export.h"
+
+#include <QFileInfo>
+
+namespace rats::service {
+
+ExportFormat exportFormatForPath(const QString& path)
+{
+    const QString suffix = QFileInfo(path).suffix().toLower();
+    if (suffix == QLatin1String("csv"))
+        return ExportFormat::Csv;
+    // ".json" is not strictly right — the file is one object per line, not one
+    // document — but somebody who typed it wants text, and JSONL is the text.
+    if (suffix == QLatin1String("jsonl") || suffix == QLatin1String("ndjson") || suffix == QLatin1String("json"))
+        return ExportFormat::JsonLines;
+    return ExportFormat::Ratsdb;
+}
+
+QString exportFormatName(ExportFormat format)
+{
+    switch (format) {
+    case ExportFormat::Csv:
+        return QStringLiteral("csv");
+    case ExportFormat::JsonLines:
+        return QStringLiteral("jsonl");
+    case ExportFormat::Ratsdb:
+        break;
+    }
+    return QStringLiteral("ratsdb");
+}
+
+std::optional<ExportFormat> exportFormatFromName(const QString& name)
+{
+    const QString key = name.trimmed().toLower();
+    if (key == QLatin1String("ratsdb"))
+        return ExportFormat::Ratsdb;
+    if (key == QLatin1String("csv"))
+        return ExportFormat::Csv;
+    if (key == QLatin1String("jsonl") || key == QLatin1String("ndjson") || key == QLatin1String("json"))
+        return ExportFormat::JsonLines;
+    return std::nullopt;
+}
+
+std::unique_ptr<TorrentSink> makeExportSink(ExportFormat format, const ExportOptions& options)
+{
+    switch (format) {
+    case ExportFormat::Csv: {
+        CsvWriter::Options csv;
+        csv.includeFiles = options.includeFiles;
+        return std::make_unique<CsvWriter>(csv);
+    }
+    case ExportFormat::JsonLines:
+        return std::make_unique<JsonLinesWriter>();
+    case ExportFormat::Ratsdb:
+        break;
+    }
+    return std::make_unique<DumpWriter>();
+}
+
+} // namespace rats::service

--- a/src/services/export_sink.h
+++ b/src/services/export_sink.h
@@ -1,0 +1,66 @@
+#ifndef RATS_SERVICE_EXPORT_SINK_H
+#define RATS_SERVICE_EXPORT_SINK_H
+
+#include "domain/torrent.h"
+
+#include <QDateTime>
+#include <QString>
+
+namespace rats::service {
+
+// Provenance of an export, written into whatever preamble the target format
+// has (the .ratsdb JSON header, a CSV comment, nothing at all). `torrents` is
+// the writer's *estimate* — the row count when the export started — so a sink
+// can size a progress bar; the exact totals are only known at finish().
+struct ExportHeader {
+    QString client; // producing client version
+    QString peerId; // producing node's peer id (informational)
+    QDateTime created;
+    qint64 torrents = 0;
+};
+
+// One output format of a whole-index export.
+//
+// DatabaseSyncService owns the hard part of an export — keyset pagination over
+// millions of rows, the worker thread, progress publishing, cancellation — and
+// knows nothing about the bytes it produces. A sink is the other half: it turns
+// the torrent stream into a file. Adding a format means adding a sink, not a
+// second export loop.
+//
+// The contract mirrors the lifecycle the exporter drives: open() once, write()
+// per torrent in id order, then exactly one of finish() (the file is complete)
+// or abort() (the file is removed). A sink is single-use and not thread-safe;
+// it lives entirely on the worker thread.
+class TorrentSink {
+public:
+    virtual ~TorrentSink() = default;
+
+    // Create/truncate `path` and write any preamble. Returns false and fills
+    // `error` if the file cannot be written.
+    virtual bool open(const QString& path, const ExportHeader& header, QString* error = nullptr) = 0;
+
+    // Append one torrent. `torrent.fileList` is populated only when the sink
+    // asked for it through needsFiles().
+    virtual bool write(const domain::Torrent& torrent, QString* error = nullptr) = 0;
+
+    // Write any trailer and close. After this the file is complete. Safe to
+    // call once; a second call is a no-op returning true.
+    virtual bool finish(QString* error = nullptr) = 0;
+
+    // Close and remove the partial output. Called on failure and cancellation,
+    // and from the destructor of a sink that was never finished.
+    virtual void abort() = 0;
+
+    // Bytes on disk so far, for progress reporting.
+    virtual qint64 bytesWritten() const = 0;
+
+    // Whether write() needs `fileList` filled in. Returning false lets the
+    // exporter skip the per-page file query entirely, which is the expensive
+    // half of a full sweep — a flat format that only records the file *count*
+    // should say so.
+    virtual bool needsFiles() const = 0;
+};
+
+} // namespace rats::service
+
+#endif // RATS_SERVICE_EXPORT_SINK_H

--- a/src/services/export_sink.h
+++ b/src/services/export_sink.h
@@ -5,6 +5,8 @@
 
 #include <QDateTime>
 #include <QString>
+#include <memory>
+#include <optional>
 
 namespace rats::service {
 
@@ -60,6 +62,33 @@ public:
     // should say so.
     virtual bool needsFiles() const = 0;
 };
+
+// Which file format an export writes.
+enum class ExportFormat {
+    Ratsdb, // the portable dump: compressed, and the only re-importable one
+    Csv, // spreadsheets and ad-hoc analysis
+    JsonLines, // newline-delimited JSON for scripts and data tools
+};
+
+// Format-specific knobs, ignored by the formats they do not apply to so that
+// callers never have to switch on the format themselves.
+struct ExportOptions {
+    bool includeFiles = false; // CSV: also write the companion file list
+};
+
+// The format `path`'s extension asks for. ".csv" and the JSON-ish suffixes map
+// to their text formats — whatever the caller meant by them, a file they can
+// open beats a binary dump — and everything else falls back to the dump.
+ExportFormat exportFormatForPath(const QString& path);
+
+// API/wire name of a format, and its inverse. fromName answers nullopt for an
+// unknown name so the caller can reject it instead of silently writing
+// something else.
+QString exportFormatName(ExportFormat format);
+std::optional<ExportFormat> exportFormatFromName(const QString& name);
+
+// The sink that writes `format`. Never null.
+std::unique_ptr<TorrentSink> makeExportSink(ExportFormat format, const ExportOptions& options);
 
 } // namespace rats::service
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "rest/api_router.h"
 #include "services/database_sync_service.h"
 #include "services/download_service.h"
+#include "services/export_sink.h"
 #include "services/indexing_service.h"
 #include "services/migration_service.h"
 #include "services/peer_registry.h"
@@ -720,8 +721,13 @@ void MainWindow::connectServiceSignals()
                 const qint64 processed = summary["processed"].toVariant().toLongLong();
                 if (operation == QLatin1String("export")) {
                     showStatusMessage(tr("Exported %1 torrents.").arg(processed), 8000);
-                    QMessageBox::information(this, tr("Export Database"),
-                        tr("Exported %1 torrents to:\n%2").arg(processed).arg(summary["path"].toString()));
+                    QString text = tr("Exported %1 torrents to:\n%2").arg(processed).arg(summary["path"].toString());
+                    // CSV and JSON Lines are written for other programs to read.
+                    if (summary["format"].toString() != QLatin1String("ratsdb")) {
+                        text += QStringLiteral("\n\n")
+                            + tr("This format is written for other programs — it cannot be imported back.");
+                    }
+                    QMessageBox::information(this, tr("Export Database"), text);
                     return;
                 }
                 if (operation == QLatin1String("peerServe")) {
@@ -1833,12 +1839,52 @@ void MainWindow::exportDatabase()
                                   .absoluteFilePath(QStringLiteral("rats-index-%1.ratsdb")
                                           .arg(QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd"))));
 
-    const QString path = QFileDialog::getSaveFileName(
-        this, tr("Export Database"), suggested, tr("Rats Database (*.ratsdb);;All Files (*)"));
+    // The file name is what picks the format (service::exportFormatForPath), so
+    // the filter only supplies a suffix when the user typed none. One rule, and
+    // the file always says what is inside it.
+    const QString ratsdbFilter = tr("Rats Database, can be imported back (*.ratsdb)");
+    const QString csvFilter = tr("CSV spreadsheet (*.csv)");
+    const QString jsonlFilter = tr("JSON Lines (*.jsonl)");
+    QString selectedFilter = ratsdbFilter;
+    QString path = QFileDialog::getSaveFileName(this, tr("Export Database"), suggested,
+        QStringList { ratsdbFilter, csvFilter, jsonlFilter, tr("All Files (*)") }.join(QStringLiteral(";;")),
+        &selectedFilter);
     if (path.isEmpty())
         return;
 
-    app_->api()->call("database.export", QJsonObject { { "path", path } }, [this](const Result& response) {
+    if (QFileInfo(path).suffix().isEmpty()) {
+        if (selectedFilter == csvFilter)
+            path += QStringLiteral(".csv");
+        else if (selectedFilter == jsonlFilter)
+            path += QStringLiteral(".jsonl");
+        else
+            path += QStringLiteral(".ratsdb");
+    }
+
+    QJsonObject params { { "path", path } };
+
+    // A CSV row is flat, so a torrent's file list can only travel as a second
+    // sheet — and this is the moment to say the export is one-way, before it
+    // runs rather than once it is too late to pick something else.
+    if (rats::service::exportFormatForPath(path) == rats::service::ExportFormat::Csv) {
+        QMessageBox confirm(this);
+        confirm.setIcon(QMessageBox::Question);
+        confirm.setWindowTitle(tr("Export Database"));
+        confirm.setText(tr("Export your index as a spreadsheet?"));
+        confirm.setInformativeText(tr("One row per torrent. A CSV cannot be imported back — export a .ratsdb "
+                                      "file to move your index to another Rats Search."));
+
+        QCheckBox* filesBox = new QCheckBox(tr("Also write the file list as a second CSV"), &confirm);
+        confirm.setCheckBox(filesBox);
+        confirm.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+        confirm.setDefaultButton(QMessageBox::Ok);
+
+        if (confirm.exec() != QMessageBox::Ok)
+            return;
+        params["includeFiles"] = filesBox->isChecked();
+    }
+
+    app_->api()->call("database.export", params, [this](const Result& response) {
         if (!response.ok()) {
             QMessageBox::warning(
                 this, tr("Export Database"), tr("Could not start the export.\n\n%1").arg(response.error()));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_rats_test(test_search_history)
 add_rats_test(test_filter_policy)
 add_rats_test(test_manticore_maintenance)
 add_rats_test(test_database_dump)
+add_rats_test(test_database_export)
 
 # The single-instance guard lives in src/bootstrap (executable-only, not in
 # ratscore), so its source is compiled straight into the test.
@@ -61,7 +62,7 @@ add_custom_target(check
     DEPENDS test_domain test_query test_infohash test_update_service
             test_config_store test_filter_policy test_content_classifier test_manticore_queries
             test_manticore_maintenance
-            test_database_dump
+            test_database_dump test_database_export
             test_single_instance
     COMMENT "Running all tests..."
 )

--- a/tests/test_database_export.cpp
+++ b/tests/test_database_export.cpp
@@ -11,6 +11,7 @@
 #include "domain/torrent.h"
 #include "domain/torrent_codec.h"
 #include "services/database_export.h"
+#include "services/export_sink.h"
 
 #include <QFile>
 #include <QFileInfo>
@@ -165,6 +166,10 @@ private slots:
     void testCsvWithoutFileListWritesNoCompanion();
     void testCsvUnfinishedWriteLeavesNoFiles();
     void testCsvEmptyExportKeepsHeader();
+
+    void testFormatFollowsFileExtension();
+    void testFormatNamesRoundTrip();
+    void testFactoryBuildsTheRightSink();
 
 private:
     QTemporaryDir dir_;
@@ -503,6 +508,69 @@ void TestDatabaseExport::testCsvEmptyExportKeepsHeader()
     const QStringList rows = readCsvRows(file);
     QCOMPARE(rows.size(), 1);
     QCOMPARE(splitCsvRow(rows.first()).at(ColHash), QStringLiteral("hash"));
+}
+
+void TestDatabaseExport::testFormatFollowsFileExtension()
+{
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.csv")) == ExportFormat::Csv);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.CSV")) == ExportFormat::Csv);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.jsonl")) == ExportFormat::JsonLines);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.ndjson")) == ExportFormat::JsonLines);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.json")) == ExportFormat::JsonLines);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.ratsdb")) == ExportFormat::Ratsdb);
+
+    // A dotted base name is not an extension.
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/my.index.csv")) == ExportFormat::Csv);
+    // Anything unrecognised stays the format that can be imported back.
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index")) == ExportFormat::Ratsdb);
+    QVERIFY(exportFormatForPath(QStringLiteral("/tmp/index.bin")) == ExportFormat::Ratsdb);
+}
+
+void TestDatabaseExport::testFormatNamesRoundTrip()
+{
+    for (const ExportFormat format : { ExportFormat::Ratsdb, ExportFormat::Csv, ExportFormat::JsonLines })
+        QVERIFY(exportFormatFromName(exportFormatName(format)) == format);
+
+    QCOMPARE(exportFormatName(ExportFormat::Csv), QStringLiteral("csv"));
+    QCOMPARE(exportFormatName(ExportFormat::JsonLines), QStringLiteral("jsonl"));
+    QVERIFY(exportFormatFromName(QStringLiteral("  CSV ")) == ExportFormat::Csv);
+    // An unknown name is rejected, not quietly turned into some other format.
+    QVERIFY(!exportFormatFromName(QStringLiteral("xlsx")).has_value());
+}
+
+void TestDatabaseExport::testFactoryBuildsTheRightSink()
+{
+    struct Case {
+        ExportFormat format;
+        bool includeFiles;
+        bool needsFiles;
+        QByteArray magic;
+        QString name;
+    };
+
+    const QList<Case> cases = {
+        { ExportFormat::Ratsdb, false, true, QByteArray("RATSDB"), QStringLiteral("sink.ratsdb") },
+        { ExportFormat::JsonLines, false, true, QByteArray("{"), QStringLiteral("sink.jsonl") },
+        // Only the flat CSV can skip the file query; that is the whole point of
+        // needsFiles().
+        { ExportFormat::Csv, false, false, QByteArray("\xEF\xBB\xBF"), QStringLiteral("sink-flat.csv") },
+        { ExportFormat::Csv, true, true, QByteArray("\xEF\xBB\xBF"), QStringLiteral("sink-files.csv") },
+    };
+
+    for (const Case& testCase : cases) {
+        ExportOptions options;
+        options.includeFiles = testCase.includeFiles;
+        const std::unique_ptr<TorrentSink> sink = makeExportSink(testCase.format, options);
+        QVERIFY(sink != nullptr);
+        QCOMPARE(sink->needsFiles(), testCase.needsFiles);
+
+        // The bytes prove which sink came back, not just its interface.
+        const QString file = path(testCase.name);
+        QVERIFY(sink->open(file, makeHeader(1)));
+        QVERIFY(sink->write(makeTorrent(0)));
+        QVERIFY(sink->finish());
+        QVERIFY(readAllBytes(file).startsWith(testCase.magic));
+    }
 }
 
 QTEST_MAIN(TestDatabaseExport)

--- a/tests/test_database_export.cpp
+++ b/tests/test_database_export.cpp
@@ -13,6 +13,7 @@
 #include "services/database_export.h"
 
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -68,6 +69,80 @@ QList<QByteArray> readRecordLines(const QString& path)
     return parts;
 }
 
+QByteArray readAllBytes(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return {};
+    return file.readAll();
+}
+
+// Rows of a CSV file, BOM stripped, split on CRLF. Splitting on CRLF is itself
+// the line-ending check: an LF-only writer would come back as one giant row.
+QStringList readCsvRows(const QString& path)
+{
+    QByteArray all = readAllBytes(path);
+    if (all.startsWith(QByteArray("\xEF\xBB\xBF")))
+        all.remove(0, 3);
+    QStringList rows = QString::fromUtf8(all).split(QStringLiteral("\r\n"));
+    if (!rows.isEmpty() && rows.last().isEmpty())
+        rows.removeLast();
+    return rows;
+}
+
+// An independent RFC 4180 field reader, so the writer is checked against a
+// different implementation instead of against itself.
+QStringList splitCsvRow(const QString& row)
+{
+    QStringList fields;
+    QString current;
+    bool quoted = false;
+    for (int i = 0; i < row.size(); ++i) {
+        const QChar c = row.at(i);
+        if (quoted) {
+            if (c != QLatin1Char('"')) {
+                current += c;
+            } else if (i + 1 < row.size() && row.at(i + 1) == QLatin1Char('"')) {
+                current += QLatin1Char('"'); // "" is one escaped quote
+                ++i;
+            } else {
+                quoted = false;
+            }
+        } else if (c == QLatin1Char('"')) {
+            quoted = true;
+        } else if (c == QLatin1Char(',')) {
+            fields << current;
+            current.clear();
+        } else {
+            current += c;
+        }
+    }
+    fields << current;
+    return fields;
+}
+
+// Column order of the torrents CSV.
+enum Col {
+    ColHash = 0,
+    ColName,
+    ColSize,
+    ColFiles,
+    ColPieceLength,
+    ColAdded,
+    ColType,
+    ColCategory,
+    ColSeeders,
+    ColLeechers,
+    ColCompleted,
+    ColTrackersChecked,
+    ColGood,
+    ColBad,
+    ColMagnet,
+    ColPoster,
+    ColDescription,
+    ColCount
+};
+
 } // namespace
 
 class TestDatabaseExport : public QObject {
@@ -80,6 +155,16 @@ private slots:
     void testJsonLinesEmptyExport();
     void testJsonLinesUnfinishedWriteLeavesNoFile();
     void testJsonLinesFlushesLargeBatches();
+
+    void testCsvHeaderAndBom();
+    void testCsvRoundTripsQuotedText();
+    void testCsvDefusesFormulaInjection();
+    void testCsvFlattensControlCharacters();
+    void testCsvWritesIsoDates();
+    void testCsvCompanionFileList();
+    void testCsvWithoutFileListWritesNoCompanion();
+    void testCsvUnfinishedWriteLeavesNoFiles();
+    void testCsvEmptyExportKeepsHeader();
 
 private:
     QTemporaryDir dir_;
@@ -217,6 +302,207 @@ void TestDatabaseExport::testJsonLinesFlushesLargeBatches()
         QCOMPARE(parse.error, QJsonParseError::NoError);
         QCOMPARE(codec::torrentFromJson(doc.object()).hash, makeTorrent(i).hash);
     }
+}
+
+void TestDatabaseExport::testCsvHeaderAndBom()
+{
+    const QString file = path(QStringLiteral("header.csv"));
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(1)));
+    QVERIFY(writer.write(makeTorrent(1)));
+    QVERIFY(writer.finish());
+
+    // Without the BOM, Excel on Windows mojibakes every non-ASCII name.
+    const QByteArray raw = readAllBytes(file);
+    QVERIFY(raw.startsWith(QByteArray("\xEF\xBB\xBF")));
+    QVERIFY(raw.endsWith(QByteArray("\r\n")));
+
+    const QStringList rows = readCsvRows(file);
+    QCOMPARE(rows.size(), 2); // header + one torrent
+
+    const QStringList header = splitCsvRow(rows.first());
+    QCOMPARE(header.size(), qsizetype(ColCount));
+    QCOMPARE(header.at(ColHash), QStringLiteral("hash"));
+    QCOMPARE(header.at(ColName), QStringLiteral("name"));
+    QCOMPARE(header.at(ColMagnet), QStringLiteral("magnet"));
+    QCOMPARE(header.at(ColDescription), QStringLiteral("description"));
+}
+
+void TestDatabaseExport::testCsvRoundTripsQuotedText()
+{
+    const QString file = path(QStringLiteral("quoting.csv"));
+
+    Torrent torrent = makeTorrent(4);
+    torrent.name = QStringLiteral("Comma, quote\" and \"\"double\"\" Кириллица");
+    torrent.info = QJsonObject { { QStringLiteral("description"), QStringLiteral("multi, field \"text\"") } };
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(1)));
+    QVERIFY(writer.write(torrent));
+    QVERIFY(writer.finish());
+
+    const QStringList rows = readCsvRows(file);
+    QCOMPARE(rows.size(), 2);
+
+    const QStringList fields = splitCsvRow(rows.at(1));
+    QCOMPARE(fields.size(), qsizetype(ColCount));
+    QCOMPARE(fields.at(ColName), torrent.name);
+    QCOMPARE(fields.at(ColDescription), QStringLiteral("multi, field \"text\""));
+    QCOMPARE(fields.at(ColHash), torrent.hash);
+    QCOMPARE(fields.at(ColSize), QString::number(torrent.size));
+    QCOMPARE(fields.at(ColType), QStringLiteral("video"));
+    QCOMPARE(fields.at(ColCategory), QStringLiteral("movie"));
+}
+
+void TestDatabaseExport::testCsvDefusesFormulaInjection()
+{
+    const QString file = path(QStringLiteral("injection.csv"));
+
+    // Every one of these is a name a stranger can publish on the DHT.
+    const QStringList dangerous = { QStringLiteral("=cmd|' /c calc'!A1"), QStringLiteral("+1+1"),
+        QStringLiteral("-2+3"), QStringLiteral("@SUM(A1)") };
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(dangerous.size())));
+    for (int i = 0; i < dangerous.size(); ++i) {
+        Torrent torrent = makeTorrent(i);
+        torrent.name = dangerous.at(i);
+        QVERIFY(writer.write(torrent));
+    }
+    QVERIFY(writer.finish());
+
+    const QStringList rows = readCsvRows(file);
+    QCOMPARE(rows.size(), dangerous.size() + 1);
+    for (int i = 0; i < dangerous.size(); ++i) {
+        // The apostrophe is what stops Excel executing the cell.
+        QCOMPARE(splitCsvRow(rows.at(i + 1)).at(ColName), QStringLiteral("'") + dangerous.at(i));
+    }
+}
+
+void TestDatabaseExport::testCsvFlattensControlCharacters()
+{
+    const QString file = path(QStringLiteral("controls.csv"));
+
+    Torrent torrent = makeTorrent(5);
+    torrent.name = QStringLiteral("line\nbreak\ttab\rreturn");
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(2)));
+    QVERIFY(writer.write(torrent));
+    QVERIFY(writer.write(makeTorrent(6)));
+    QVERIFY(writer.finish());
+
+    // The RFC would allow the newline inside quotes; too many readers mishandle
+    // it, so one torrent stays one physical row.
+    const QStringList rows = readCsvRows(file);
+    QCOMPARE(rows.size(), 3);
+    QCOMPARE(splitCsvRow(rows.at(1)).at(ColName), QStringLiteral("line break tab return"));
+}
+
+void TestDatabaseExport::testCsvWritesIsoDates()
+{
+    const QString file = path(QStringLiteral("dates.csv"));
+
+    const Torrent torrent = makeTorrent(0);
+    QVERIFY(!torrent.trackersChecked.isValid()); // never scraped
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(1)));
+    QVERIFY(writer.write(torrent));
+    QVERIFY(writer.finish());
+
+    const QStringList fields = splitCsvRow(readCsvRows(file).at(1));
+    QCOMPARE(fields.at(ColAdded), torrent.added.toUTC().toString(Qt::ISODate));
+    QVERIFY(fields.at(ColAdded).endsWith(QLatin1Char('Z')));
+    // "Never scraped" is an empty cell, not an event in 1970.
+    QVERIFY(fields.at(ColTrackersChecked).isEmpty());
+}
+
+void TestDatabaseExport::testCsvCompanionFileList()
+{
+    const QString file = path(QStringLiteral("with-files.csv"));
+
+    CsvWriter::Options options;
+    options.includeFiles = true;
+    CsvWriter writer(options);
+    QVERIFY(writer.needsFiles());
+    QVERIFY(writer.open(file, makeHeader(3)));
+    for (int i = 0; i < 3; ++i)
+        QVERIFY(writer.write(makeTorrent(i)));
+    QVERIFY(writer.finish());
+
+    QCOMPARE(writer.torrentsWritten(), qint64(3));
+    QCOMPARE(writer.filesWritten(), qint64(6)); // two files each
+
+    const QString companion = writer.filesPath();
+    QCOMPARE(QFileInfo(companion).fileName(), QStringLiteral("with-files.files.csv"));
+    QVERIFY(QFile::exists(companion));
+
+    const QStringList rows = readCsvRows(companion);
+    QCOMPARE(rows.size(), 7); // header + six files
+    QCOMPARE(splitCsvRow(rows.first()),
+        QStringList({ QStringLiteral("hash"), QStringLiteral("path"), QStringLiteral("size") }));
+
+    // A file row joins back to its torrent on hash — that is the whole contract
+    // of splitting the export in two.
+    const Torrent expected = makeTorrent(0);
+    const QStringList first = splitCsvRow(rows.at(1));
+    QCOMPARE(first.at(0), expected.hash);
+    QCOMPARE(first.at(1), expected.fileList[0].path);
+    QCOMPARE(first.at(2), QString::number(expected.fileList[0].size));
+}
+
+void TestDatabaseExport::testCsvWithoutFileListWritesNoCompanion()
+{
+    const QString file = path(QStringLiteral("flat.csv"));
+
+    CsvWriter writer; // default: torrents only
+    QVERIFY(!writer.needsFiles());
+    QVERIFY(writer.open(file, makeHeader(1)));
+    QVERIFY(writer.write(makeTorrent(2))); // carries a file list that must be ignored
+    QVERIFY(writer.finish());
+
+    QVERIFY(writer.filesPath().isEmpty());
+    QCOMPARE(writer.filesWritten(), qint64(0));
+    QVERIFY(!QFile::exists(path(QStringLiteral("flat.files.csv"))));
+
+    // The file *count* still lands: it lives on the torrent row, so skipping the
+    // file query costs the flat export nothing.
+    QCOMPARE(splitCsvRow(readCsvRows(file).at(1)).at(ColFiles), QStringLiteral("2"));
+}
+
+void TestDatabaseExport::testCsvUnfinishedWriteLeavesNoFiles()
+{
+    const QString file = path(QStringLiteral("unfinished.csv"));
+    const QString companion = path(QStringLiteral("unfinished.files.csv"));
+
+    {
+        CsvWriter::Options options;
+        options.includeFiles = true;
+        CsvWriter writer(options);
+        QVERIFY(writer.open(file, makeHeader(1)));
+        QVERIFY(writer.write(makeTorrent(0)));
+        // Destroyed without finish().
+    }
+
+    // Both halves go: a companion outliving its export would be worse than none.
+    QVERIFY(!QFile::exists(file));
+    QVERIFY(!QFile::exists(companion));
+}
+
+void TestDatabaseExport::testCsvEmptyExportKeepsHeader()
+{
+    const QString file = path(QStringLiteral("empty.csv"));
+
+    CsvWriter writer;
+    QVERIFY(writer.open(file, makeHeader(0)));
+    QVERIFY(writer.finish());
+
+    // A header-only sheet is the right answer for an empty index.
+    const QStringList rows = readCsvRows(file);
+    QCOMPARE(rows.size(), 1);
+    QCOMPARE(splitCsvRow(rows.first()).at(ColHash), QStringLiteral("hash"));
 }
 
 QTEST_MAIN(TestDatabaseExport)

--- a/tests/test_database_export.cpp
+++ b/tests/test_database_export.cpp
@@ -1,0 +1,223 @@
+/**
+ * @file test_database_export.cpp
+ * @brief Unit tests for the interchange export formats (JsonLinesWriter).
+ *        These files are read by programs that are not Rats — jq, pandas,
+ *        DuckDB — so the exact bytes are the contract: one record per physical
+ *        line, no preamble, nothing but torrents.
+ */
+
+#include <QtTest/QtTest>
+
+#include "domain/torrent.h"
+#include "domain/torrent_codec.h"
+#include "services/database_export.h"
+
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QTemporaryDir>
+
+using namespace rats::domain;
+using namespace rats::service;
+
+namespace {
+
+Torrent makeTorrent(int index)
+{
+    Torrent t;
+    t.hash = QStringLiteral("%1").arg(index, 40, 16, QLatin1Char('0'));
+    t.name = QStringLiteral("Torrent number %1").arg(index);
+    t.size = 1024LL * 1024LL * (index + 1);
+    t.files = 2;
+    t.pieceLength = 262144;
+    t.added = QDateTime::fromSecsSinceEpoch(1700000000 + index);
+    t.contentType = ContentType::Video;
+    t.contentCategory = ContentCategory::Movie;
+    t.seeders = index;
+    t.leechers = index * 2;
+    t.good = index % 5;
+    t.bad = index % 3;
+    t.fileList = { File { QStringLiteral("dir/file%1.mkv").arg(index), t.size - 100 },
+        File { QStringLiteral("dir/readme%1.txt").arg(index), 100 } };
+    return t;
+}
+
+ExportHeader makeHeader(qint64 torrents)
+{
+    ExportHeader header;
+    header.client = QStringLiteral("2.2.4");
+    header.peerId = QStringLiteral("abcdef");
+    header.created = QDateTime::fromSecsSinceEpoch(1700000000);
+    header.torrents = torrents;
+    return header;
+}
+
+// Split the file into records. A well-formed JSONL file ends with LF, so the
+// final split part is empty and is dropped; any *other* empty element survives
+// and fails the JSON parse below, which is exactly what a stray blank line
+// should do.
+QList<QByteArray> readRecordLines(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return {};
+    QList<QByteArray> parts = file.readAll().split('\n');
+    if (!parts.isEmpty() && parts.last().isEmpty())
+        parts.removeLast();
+    return parts;
+}
+
+} // namespace
+
+class TestDatabaseExport : public QObject {
+    Q_OBJECT
+
+private slots:
+    void testJsonLinesRoundTrip();
+    void testJsonLinesHasNoPreamble();
+    void testJsonLinesKeepsOneRecordPerLine();
+    void testJsonLinesEmptyExport();
+    void testJsonLinesUnfinishedWriteLeavesNoFile();
+    void testJsonLinesFlushesLargeBatches();
+
+private:
+    QTemporaryDir dir_;
+    QString path(const QString& name) const { return dir_.filePath(name); }
+};
+
+void TestDatabaseExport::testJsonLinesRoundTrip()
+{
+    const QString file = path(QStringLiteral("roundtrip.jsonl"));
+
+    JsonLinesWriter writer;
+    QVERIFY(writer.open(file, makeHeader(3)));
+    for (int i = 0; i < 3; ++i)
+        QVERIFY(writer.write(makeTorrent(i)));
+    QVERIFY(writer.finish());
+    QCOMPARE(writer.torrentsWritten(), qint64(3));
+
+    const QList<QByteArray> lines = readRecordLines(file);
+    QCOMPARE(lines.size(), 3);
+
+    for (int i = 0; i < 3; ++i) {
+        QJsonParseError parse {};
+        const QJsonDocument doc = QJsonDocument::fromJson(lines.at(i), &parse);
+        QCOMPARE(parse.error, QJsonParseError::NoError);
+        QVERIFY(doc.isObject());
+
+        const Torrent got = codec::torrentFromJson(doc.object());
+        const Torrent expected = makeTorrent(i);
+        QCOMPARE(got.hash, expected.hash);
+        QCOMPARE(got.name, expected.name);
+        QCOMPARE(got.size, expected.size);
+        QCOMPARE(got.files, expected.files);
+        QVERIFY(got.contentType == expected.contentType);
+        QVERIFY(got.contentCategory == expected.contentCategory);
+        QCOMPARE(got.seeders, expected.seeders);
+        QCOMPARE(got.good, expected.good);
+        QCOMPARE(got.bad, expected.bad);
+        // JSONL is the lossless view: the file list rides along.
+        QCOMPARE(got.fileList.size(), 2);
+        QCOMPARE(got.fileList[0].path, expected.fileList[0].path);
+        QCOMPARE(got.fileList[0].size, expected.fileList[0].size);
+    }
+}
+
+void TestDatabaseExport::testJsonLinesHasNoPreamble()
+{
+    const QString file = path(QStringLiteral("preamble.jsonl"));
+
+    JsonLinesWriter writer;
+    QVERIFY(writer.open(file, makeHeader(2)));
+    QVERIFY(writer.write(makeTorrent(7)));
+    QVERIFY(writer.write(makeTorrent(8)));
+    QVERIFY(writer.finish());
+
+    // Two torrents in, two lines out: the provenance header is accepted and
+    // dropped, because a metadata line would break every JSONL reader.
+    const QList<QByteArray> lines = readRecordLines(file);
+    QCOMPARE(lines.size(), 2);
+
+    const QJsonObject first = QJsonDocument::fromJson(lines.first()).object();
+    QCOMPARE(first.value(QStringLiteral("hash")).toString(), makeTorrent(7).hash);
+    QVERIFY(!first.contains(QStringLiteral("format")));
+    QVERIFY(!first.contains(QStringLiteral("client")));
+}
+
+void TestDatabaseExport::testJsonLinesKeepsOneRecordPerLine()
+{
+    const QString file = path(QStringLiteral("specials.jsonl"));
+
+    // A DHT-sourced name can carry anything, newlines included. JSON escaping
+    // has to keep the record on one physical line or every reader loses sync.
+    Torrent nasty = makeTorrent(1);
+    nasty.name = QStringLiteral("Quote\" comma, tab\t newline\n backslash\\ Кириллица 日本語");
+
+    JsonLinesWriter writer;
+    QVERIFY(writer.open(file, makeHeader(2)));
+    QVERIFY(writer.write(nasty));
+    QVERIFY(writer.write(makeTorrent(2)));
+    QVERIFY(writer.finish());
+
+    const QList<QByteArray> lines = readRecordLines(file);
+    QCOMPARE(lines.size(), 2);
+
+    const Torrent got = codec::torrentFromJson(QJsonDocument::fromJson(lines.first()).object());
+    QCOMPARE(got.name, nasty.name);
+}
+
+void TestDatabaseExport::testJsonLinesEmptyExport()
+{
+    const QString file = path(QStringLiteral("empty.jsonl"));
+
+    JsonLinesWriter writer;
+    QVERIFY(writer.open(file, makeHeader(0)));
+    QVERIFY(writer.finish());
+
+    // An index with nothing in it is a valid, empty JSONL file — not a failure.
+    QVERIFY(QFile::exists(file));
+    QCOMPARE(QFileInfo(file).size(), qint64(0));
+    QCOMPARE(writer.torrentsWritten(), qint64(0));
+}
+
+void TestDatabaseExport::testJsonLinesUnfinishedWriteLeavesNoFile()
+{
+    const QString file = path(QStringLiteral("unfinished.jsonl"));
+
+    {
+        JsonLinesWriter writer;
+        QVERIFY(writer.open(file, makeHeader(1)));
+        QVERIFY(writer.write(makeTorrent(0)));
+        // Destroyed without finish() — a cancelled export must not leave a file
+        // that looks like a complete one.
+    }
+
+    QVERIFY(!QFile::exists(file));
+}
+
+void TestDatabaseExport::testJsonLinesFlushesLargeBatches()
+{
+    const QString file = path(QStringLiteral("large.jsonl"));
+    constexpr int kCount = 2000; // comfortably past the 256 KB write buffer
+
+    JsonLinesWriter writer;
+    QVERIFY(writer.open(file, makeHeader(kCount)));
+    for (int i = 0; i < kCount; ++i)
+        QVERIFY(writer.write(makeTorrent(i)));
+    QVERIFY(writer.finish());
+
+    const QList<QByteArray> lines = readRecordLines(file);
+    QCOMPARE(lines.size(), kCount);
+
+    // The buffered flush must not tear a record: check the seam-prone ones.
+    for (int i : { 0, kCount / 2, kCount - 1 }) {
+        QJsonParseError parse {};
+        const QJsonDocument doc = QJsonDocument::fromJson(lines.at(i), &parse);
+        QCOMPARE(parse.error, QJsonParseError::NoError);
+        QCOMPARE(codec::torrentFromJson(doc.object()).hash, makeTorrent(i).hash);
+    }
+}
+
+QTEST_MAIN(TestDatabaseExport)
+#include "test_database_export.moc"


### PR DESCRIPTION
This is my first try on creating PR to this codebase. I opened to critique and suggestions. I tried to comment as much as possible for easier review.

## Design decisions

- **Formats**
  - `.ratsdb` is unchanged and stays the only re-importable format; CSV and JSON Lines are one-way exports written for other programs to read.
  - JSONL lines are byte-identical to the ones inside a `.ratsdb` frame (same `domain::codec::toJson`), so the two exports can't drift apart and JSONL is the
  lossless option.
  - No preamble line in JSONL — `jq`, `pandas.read_json(lines=True)` and DuckDB all assume every line is a record.
  - CSV is deliberately lossy: `info` reduces to `poster`/`description`, and the file list moves to an opt-in companion `<base>.files.csv` that joins back on
  `hash`.

- **Architecture**
  - New `TorrentSink` interface, implemented by `DumpWriter` too: `DatabaseSyncService` keeps the single export loop (keyset pagination, worker thread,
  progress, cancel) and a new format is a new sink, not a second loop.
  - `needsFiles()` lets a flat CSV skip the per-page `filesOf()` query — the expensive half of a full sweep. The `files` count still lands; it lives on the
  torrent row.
  - Peer serving is pinned to `ratsdb` regardless of what the user last exported by hand.
  - Unfinished writers remove their output on destruction, and a CSV's two files always live or die together.

---

I disclose that I have used LLM based tooling while creating this PR but I have manually checked all diffs and tests.